### PR TITLE
Removed support for illuminate/support ^6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "illuminate/support": "^6.0|^7.0"
+        "illuminate/support": "^7.0"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0",


### PR DESCRIPTION
L7 uses the Throwable interface where's Laravel 6 still uses the Exception class.